### PR TITLE
JWT Payload type change request

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -54,7 +54,7 @@ class Metadata(BaseModel):
 class JWTPayload(BaseModel):
     sub: str
     name: str
-    iat: int
-    exp: int
+    iat: float
+    exp: float
     context: Optional[str]
     context_role: str = Field(alias="context-role")


### PR DESCRIPTION
This PR changes the type of JWT payload params (iat & exp) from int to float.

#### Reason
The library used to issue JWT token in ki-toolbox only works with `DateTimeImmutable` for **reserved** claims (iat & exp) which at the end generates float numbers for those claims.